### PR TITLE
Support authentication method for new FritzOS versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,5 +27,3 @@ require (
 	google.golang.org/protobuf v1.21.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace github.com/bpicode/fritzctl => github.com/jayme-github/fritzctl v1.4.23-0.20220609211037-25a9f8556e3b

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/jayme-github/fritzbox_smarthome_exporter
 
 go 1.17
 
+replace github.com/bpicode/fritzctl => github.com/matthiasfraass/fritzctl v1.4.24_mf
+
 require (
 	github.com/bpicode/fritzctl v1.4.24-0.20210413183853-48944781b59f
 	github.com/namsral/flag v1.7.4-pre

--- a/main.go
+++ b/main.go
@@ -126,6 +126,10 @@ func main() {
 		options = append(options, fritz.Certificate(crt))
 	}
 
+	if fbURL.RequestURI() != "/" {
+		options = append(options, fritz.AuthEndpoint(fbURL.RequestURI()))
+	}
+
 	fritzClient = NewClient(options...)
 
 	if err := fritzClient.SafeLogin(); err != nil {


### PR DESCRIPTION
Fixes
https://github.com/jayme-github/fritzbox_smarthome_exporter/issues/18
by using a new authenticator via new fritzctl